### PR TITLE
Fix repeated listener registration in useToast hook

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent multiple listener registrations in `useToast` by only subscribing once

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any type errors and other lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_689d0b44dafc832b8b74d9b6df40521c