### PR TITLE
fix: export db from database module

### DIFF
--- a/src/db/vermyDb.ts
+++ b/src/db/vermyDb.ts
@@ -38,7 +38,8 @@ class VermyDatabase extends Dexie {
   }
 }
 
-export const vermyDb = new VermyDatabase();
+export const db = new VermyDatabase();
+export const vermyDb = db;
 
 export const nowIso = () => new Date().toISOString();
 


### PR DESCRIPTION
## Summary
- export `db` alongside `vermyDb` so repositories can import it

## Testing
- `npx vite --host 0.0.0.0 --port 5173 --clearScreen false`
- `npm run lint` *(fails: Unexpected any, no-empty block, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689d91b98038832baf69c52aa3ad2e82